### PR TITLE
Fix TS1203 error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -86,4 +86,5 @@ class ExifTransformer extends Transform {
   }
 }
 
-export = ExifTransformer
+export default ExifTransformer
+module.exports = ExifTransformer


### PR DESCRIPTION
Hey! @joshbuddy 

Currently, when targeting ECMAScript modules in tsconfig.json (e.q. "target": "ES2017") and using this library it fails on the build stage with the error:

```
[tsl] ERROR in /workspace/node_modules/exif-be-gone/index.ts(89,1)
TS1203: Export assignment cannot be used when targeting ECMAScript modules. 
Consider using 'export default' or another module format instead.
```

Using new export statements should work for every use case.